### PR TITLE
Drop `all_projects` flag and browse available projects and trusts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,20 @@ This project comes with one command `cinder-snapshooter` with the following subc
  * `creator`: Creates automatic snapshots on volumes needing one
  * `destroyer`: Destroys expired snapshots
  
-Both commands have a `dry-run` and `all-projects` flag to control the behavior, refer
+Both commands have a `dry-run` flag to control the behavior, refer
 to the commands `--help` for more details.
 
 To enroll a volume to automatic snapshot creation it must have the `automatic_snapshots` property set to `true`,
 you can do so using the following openstack command:
 ```commandline
 openstack volume set --property automatic_snapshots=true "<volume_id>"
+```
+
+If the user doing the snapshot creation has no rights on your project you can issue a trust to give them the right
+to create the snapshots (please be mindful it may give this user a lot more permissions on your project, be sure you
+trust that user):
+```sh
+openstack trust create --role member --project "<project_id>" "<your_user_id>" "<trusted_user_id>"
 ```
 
 ### Use the docker image
@@ -84,7 +91,6 @@ User=cinder-snapshooter
 Some configuration options are available using environment variables for ease of use:
 
  * OS_CLOUD: Name of the cloud to use in your clouds.yml file
- * ALL_PROJECTS: Whether to work on all projects or not (requires a user with the appropriate rights, usually admin)
  
 
 ## Run tests

--- a/src/cinder_snapshooter/snapshot_creator.py
+++ b/src/cinder_snapshooter/snapshot_creator.py
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import datetime
-import os
 import sys
 
 import structlog
@@ -34,7 +33,6 @@ cmd_help = "Creates automatic snapshots"
 def create_snapshot_if_needed(
     volume,
     os_client,
-    all_projects,
     dry_run,
 ):
     """Create a snapshot if there isn't one for this volume today
@@ -42,7 +40,6 @@ def create_snapshot_if_needed(
     will expire in 3 months
     """
     volume_snapshots = os_client.block_storage.snapshots(
-        all_projects=all_projects,
         status="available",
         volume_id=volume.id,
     )
@@ -97,13 +94,11 @@ def create_snapshot_if_needed(
     return created_snapshots
 
 
-def process_volumes(os_client, dry_run, all_projects):
+def process_volumes(os_client, dry_run):
     """Process all volumes searching for the ones with automatic snapshots"""
-    all_projects = True if all_projects else None
     snapshot_created = 0
     errors = 0
     for volume in os_client.block_storage.volumes(
-        all_projects=all_projects,
     ):
         if volume.status not in ["available", "in-use"]:
             continue
@@ -114,7 +109,6 @@ def process_volumes(os_client, dry_run, all_projects):
                     create_snapshot_if_needed(
                         volume,
                         os_client,
-                        all_projects,
                         dry_run,
                     )
                 )
@@ -133,18 +127,11 @@ def register_args(parser):
         action="store_true",
         help="Do not create any snapshot, only pretend to",
     )
-    parser.add_argument(
-        "-a",
-        "--all-projects",
-        help="Run on all projects",
-        action="store_true",
-        default=str2bool(os.environ.get("ALL_PROJECTS", "false")),
-    )
 
 
 def cli(args):
     """Entrypoint for CLI subcommand"""
 
-    if process_volumes(args.os_client, args.dry_run, args.all_projects):
+    if process_volumes(args.os_client, args.dry_run):
         return
     sys.exit(1)  # Something went wrong during execution exit with 1

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -32,3 +32,15 @@ class FakeSnapshot:
     metadata: dict
     volume_id: str
     created_at: str
+
+
+@dataclass
+class FakeProject:
+    id: str
+    name: str
+
+
+@dataclass
+class FakeTrust:
+    id: str
+    project_id: str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,6 @@ import cinder_snapshooter.snapshot_destroyer
             argparse.Namespace(
                 os_cloud="hello",
                 devel=True,
-                all_projects=False,
                 dry_run=False,
                 verbose=3,
                 func=cinder_snapshooter.snapshot_destroyer.cli,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,6 @@ import cinder_snapshooter.snapshot_destroyer
             argparse.Namespace(
                 os_cloud="hello",
                 devel=True,
-                all_projects=False,
                 dry_run=False,
                 verbose=0,
                 func=cinder_snapshooter.snapshot_creator.cli,

--- a/tests/test_snapshot_creator.py
+++ b/tests/test_snapshot_creator.py
@@ -35,25 +35,20 @@ def test_cli(mocker, faker, success):
     cinder_snapshooter.snapshot_creator.process_volumes.return_value = success
     fake_args = argparse.Namespace(
         dry_run=faker.boolean(),
-        all_projects=faker.boolean(),
         os_client=mocker.MagicMock(),
     )
     cinder_snapshooter.snapshot_creator.cli(fake_args)
     cinder_snapshooter.snapshot_creator.process_volumes.assert_called_once_with(
         fake_args.os_client,
         fake_args.dry_run,
-        fake_args.all_projects,
     )
     if not success:
         sys.exit.assert_called_once_with(1)
 
 
-@pytest.mark.parametrize(
-    "all_projects", [True, False], ids=["single_project", "all_projects"]
-)
 @pytest.mark.parametrize("dry_run", [True, False], ids=["dry_run", "real_run"])
 @pytest.mark.parametrize("success", [True, False])
-def test_process_volumes(mocker, faker, log, all_projects, dry_run, success):
+def test_process_volumes(mocker, faker, log, dry_run, success):
     os_client = mocker.MagicMock()
     mocker.patch("cinder_snapshooter.snapshot_creator.create_snapshot_if_needed")
 
@@ -90,7 +85,7 @@ def test_process_volumes(mocker, faker, log, all_projects, dry_run, success):
     ok_volumes += nok_volumes
     volumes += ok_volumes
 
-    def create_snapshot_if_needed(ivolume, _client, _all_projects, _dry_run):
+    def create_snapshot_if_needed(ivolume, _client, _dry_run):
         if ivolume in nok_volumes:
             raise Exception()
         return ["a snapshot"]
@@ -102,13 +97,10 @@ def test_process_volumes(mocker, faker, log, all_projects, dry_run, success):
 
     assert (
         cinder_snapshooter.snapshot_creator.process_volumes(
-            os_client, dry_run, all_projects
+            os_client, dry_run
         )
         == success
     )
-    if not all_projects:
-        all_projects = None
-
     assert (
         cinder_snapshooter.snapshot_creator.create_snapshot_if_needed.call_count
         == len(ok_volumes)
@@ -117,11 +109,10 @@ def test_process_volumes(mocker, faker, log, all_projects, dry_run, success):
         cinder_snapshooter.snapshot_creator.create_snapshot_if_needed.assert_any_call(
             volume,
             os_client,
-            all_projects,
             dry_run,
         )
 
-    os_client.block_storage.volumes.assert_called_once_with(all_projects=all_projects)
+    os_client.block_storage.volumes.assert_called_once_with()
     assert log.has(
         "All volumes processed",
         errors=len(nok_volumes),
@@ -129,15 +120,12 @@ def test_process_volumes(mocker, faker, log, all_projects, dry_run, success):
     )
 
 
-@pytest.mark.parametrize(
-    "all_projects", [None, True], ids=["single_project", "all_projects"]
-)
 @pytest.mark.parametrize("dry_run", [False, True], ids=["real_run", "dry_run"])
 @pytest.mark.parametrize(
     "last_snapshot", ["never", "last_year", "in_year", "in_month", "in_day"]
 )
 def test_create_snapshot_if_needed(
-    mocker, faker, time_machine, all_projects, dry_run, last_snapshot
+    mocker, faker, time_machine, dry_run, last_snapshot
 ):
     volume = FakeVolume(
         id=faker.uuid4(), status="available", metadata={"automatic_snapshots": "true"}
@@ -206,10 +194,9 @@ def test_create_snapshot_if_needed(
     time_machine.move_to(now)
 
     return_value = cinder_snapshooter.snapshot_creator.create_snapshot_if_needed(
-        volume, os_client, all_projects, dry_run
+        volume, os_client, dry_run
     )
     os_client.block_storage.snapshots.assert_called_once_with(
-        all_projects=all_projects,
         status="available",
         volume_id=volume.id,
     )


### PR DESCRIPTION
The creation of snapshots using the `all_projects` flag is broken as the snapshots created this way gets created in the current project instead of volume's project.

This PR fix the issue by dropping the flag as well as changing the "standard" behavior to iterate over all available projects the user have rights on, either directly or via a trust.